### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Now configure the FRITZ!Box router to push IP changes towards this service. Log 
 | Password   | Enter '_' if `DYNDNS_SERVER_PASSWORD` env is unset                                    |
 
 If you specified credentials you need to append them as additional GET parameters into the Update-URL
-like `&username=<user>&password=<pass>`.
+like `&username=<username>&password=<pass>`.
 
 ### FRITZ!Box polling
 


### PR DESCRIPTION
https://avm.de/service/wissensdatenbank/dok/FRITZ-Box-7590/30_Dynamic-DNS-in-FRITZ-Box-einrichten/

it is `username` and not `user`.

Thanks alot for your work 🙏 exactly what I was looking for 🙇 